### PR TITLE
Make it compile cleanly

### DIFF
--- a/about.c
+++ b/about.c
@@ -117,15 +117,15 @@ void Snowfall (int christmastree) {
 	int wind = 1;			/* 1: wind active, 0: inactive 
 							   set to 1 here so the first loop run clears it. */
 	int newflake = 0;		/* Time until a new flake appears. */
-	
+
 	/* Set ncurses halfdelay mode. */
 	halfdelay (3);
-	
+
 	/* White snowflakes! */
 	/* Doesn't work on white terminal background... obviously.
 	attron (COLOR_PAIR(16));
 	attron (WA_BOLD); */
-	
+
 	while (1) {
 		/* Set up the storm. */
 		if (windtimer == 0) {
@@ -161,7 +161,7 @@ void Snowfall (int christmastree) {
 			new->oldchar = new->oldchar2 = ' ';
 			new->vspeed = 1+(float)rand() / (float)RAND_MAX * 2;
 			new->hspeed = (1+(float)rand() / (float)RAND_MAX * 7)-4;
-			
+
 			/* Add our new snowflake to the pointer chain. */
 			new->next = NULL;
 			if (first == NULL) {
@@ -173,7 +173,7 @@ void Snowfall (int christmastree) {
 					new->prev = new->prev->next;
 				new->prev->next = new;
 			}
-			
+
 			/* Set new counter until next snowflake. */
 			newflake = 1+(float)rand() / (float)RAND_MAX * 2;
 			/*
@@ -181,7 +181,7 @@ void Snowfall (int christmastree) {
 			mvprintw (1,1,"New flake in %d rounds.", newflake);
 			*/
 		}
-		
+
 		for (cur = first; cur != NULL; cur = curnext) {
 			curnext = cur->next;
 			/* Draw every snowflake at its coordinates to the screen. */
@@ -204,7 +204,7 @@ void Snowfall (int christmastree) {
 					if ((cur->oldx < 14) && (cur->oldx > 9) && (cur->oldy < 24) && (cur->oldy > 20)) {
 						attroff (COLOR_PAIR(12));
 					}
-					
+
 					if (christmastree)
 						ChristmasTree();
 				}
@@ -214,7 +214,7 @@ void Snowfall (int christmastree) {
 			}
 			/* Set new hspeed for flake */
 			cur->hspeed = (1+(float)rand() / (float)RAND_MAX * 7)-4;
-			
+
 			/* Advance every flake downwards by a random amount and to
 			   the left or right.
 			   Check if the next position would obscure a character on the screen
@@ -223,7 +223,7 @@ void Snowfall (int christmastree) {
 			if (wind)
 				cur->hspeed += windspeed;
 			cur->x += cur->hspeed;
-			
+
 			if (cur->y > LINES) {
 				if (cur == first) {
 					first = first->next;
@@ -237,7 +237,7 @@ void Snowfall (int christmastree) {
 				free (cur);
 				continue;
 			}
-			
+
 			/* Only draw if we're still inside the window. */
 			if (cur->y <= LINES) {
 				/*
@@ -254,12 +254,12 @@ void Snowfall (int christmastree) {
 					cur->oldchar = ' ';
 			}
 		}
-	
+
 		windtimer--;
 		newflake--;
-		
+
 		refresh();
-		
+
 		/* Leave loop if anykey(tm) was pressed. */
 		if (getch() != ERR)
 			break;
@@ -319,7 +319,7 @@ void xmasAbout (void) {
 	mvaddstr (19, 29, "Fernando J. Pereda, Marco Cova");
 	mvaddstr (20, 29, "Cheng-Lung Sung, Dmitry Petukhov");
 	mvaddstr (21, 29, "Douglas Campos");
-	
+
 	Snowfall(1);
 }
 
@@ -331,7 +331,7 @@ void SHDrawGun (int gun_pos) {
 	clrtoeol();
 	move (LINES-2, 0);
 	clrtoeol();
-	
+
 	attron (WA_BOLD);
 	mvaddstr (LINES-3, gun_pos-3, "___/\\___");
 	mvaddstr (LINES-2, gun_pos-3, "|######|");
@@ -350,27 +350,27 @@ void SHDrawScore (int score, int level) {
 	int i, len;
 	char scorestr[16];
 	char levelstr[16];
-	
+
 	attron (WA_REVERSE);
 	for (i = 0; i < COLS; i++) {
 		mvaddch (0, i, ' ');
 	}
 	mvaddstr (0, 1, "Santa Hunta!");
-	
+
 	snprintf (scorestr, sizeof(scorestr), _("Score: %d"), score);
 	len = strlen (scorestr);
 	mvaddstr (0, COLS-1-len, scorestr);
-	
+
 	snprintf (levelstr, sizeof(levelstr), _("Level: %d"), level);
 	len = strlen (levelstr);
 	mvaddstr (0, COLS/2-len/2, levelstr);
-	
+
 	attroff (WA_REVERSE);
 }
 
 void SHClearScreen (void) {
 	int i;
-	
+
 	for (i = 0; i < LINES; i++) {
 		move (i, 0);
 		clrtoeol();
@@ -386,9 +386,9 @@ void SHDrawProjectile (shot shot) {
 void SHDrawSanta (santa santa) {
 	int len;
 	char *draw_string;
-	
+
 	len = COLS - santa.x;
-	
+
 	if (santa.anim == 0) {
 		if (santa.x < 0) {
 			draw_string = santa.gfx+abs(santa.x);
@@ -412,7 +412,7 @@ void SHDrawSanta (santa santa) {
 		} else
 			mvaddnstr (santa.y+1, santa.x, santa.altgfx_line2, len);
 	}
-	
+
 	attron (COLOR_PAIR(10));
 	mvaddch (santa.y, santa.x + santa.length - 1, '*');
 	attroff (COLOR_PAIR(10));
@@ -445,9 +445,9 @@ int SHAddScore (santa santa) {
 
 void SHDrawHitScore (scoreDisplay score) {
 	int rand_color;
-	
+
 	rand_color = 10 + ((float)rand() / (float)RAND_MAX * 6);
-	
+
 	attron (WA_BOLD);
 	attron (COLOR_PAIR(rand_color));
 	mvprintw (score.y, score.x, "%d", score.score);
@@ -472,15 +472,15 @@ void printFinalScore (int score) {
 	int y;
 	int divisor;
 	int digit;
-	
+
 	if (score == 0)
 		number_count = 1;
 	else
 		number_count = log10(score) + 1;
-	
-	
+
+
 	pos = COLS/2 - ((number_count * 8) / 2);
-	
+
 	for (i = 0; i < number_count; i++) {
 		y = 12;
 		divisor = pow (10, number_count-1-i);
@@ -491,30 +491,30 @@ void printFinalScore (int score) {
 			mvaddstr (y, pos + (i * 8), numbers[digit][j]);
 			y++;
 		}
-	}	
+	}
 	refresh();
 }
 
 void SHFinalScore (int score) {
 	int rand_color;
 
-	attron (WA_BOLD);	
+	attron (WA_BOLD);
 	mvaddstr (9, COLS/2-6, "Final score:");
 	refresh();
 	sleep(1);
-	
-	
+
+
 	for (;;) {
 		if (getch() == 'q')
 			break;
-		
+
 		rand_color = 10 + ((float)rand() / (float)RAND_MAX * 6);
 		attron (WA_BOLD);
 		attron (COLOR_PAIR(rand_color));
 		printFinalScore(score);
 		attroff (COLOR_PAIR(rand_color));
 		attroff (WA_BOLD);
-		
+
 		move (LINES-1, COLS-1);
 		refresh();
 	}
@@ -530,7 +530,6 @@ void santaHunta (void) {
 	int level = 1;
 	struct timeval before;
 	struct timeval after;
-	struct timeval delay;
 	int draw_loop = 0;
 	long draw_delay = 0;
 	shot shot;
@@ -538,31 +537,27 @@ void santaHunta (void) {
 	int targets = 0;
 	int hitcount = 0;
 	scoreDisplay scoreDisplay;
-	
+
 	shot.fired = 0;
 	shot.x = 0;
 	shot.y = 0;
-	
+
 	scoreDisplay.rounds = 0;
-	
+
 	/* Set ncurses halfdelay mode.
 	 * Max resolution is 1/10sec */
 	halfdelay (1);
-	
-	for (;;) {	
+
+	for (;;) {
 		gettimeofday (&before, NULL);
 		input = getch();
 		gettimeofday (&after, NULL);
 
 		if (after.tv_sec > before.tv_sec)
 			after.tv_usec += 1000000;
-		
-		delay.tv_sec = 0;
-		delay.tv_usec = abs(100000 - (after.tv_usec - before.tv_usec));
 
 		if (!targets) {
 			newSanta(&santa, level);
-			
 			targets = 1;
 		}
 
@@ -576,41 +571,41 @@ void santaHunta (void) {
 
 			if (targets)
 				SHDrawSanta(santa);
-			
+
 			if (santa.anim == 0)
 				santa.anim = 1;
 			else
 				santa.anim = 0;
-				
+
 			if (santa.x >= COLS)
 				targets = 0;
-			
+
 			if (shot.fired)
 				SHDrawProjectile(shot);
-				
+
 			if (scoreDisplay.rounds > 0)
 				SHDrawHitScore(scoreDisplay);
-			
+
 			if (SHHit(shot, santa)) {
 				targets = 0;
 				hitcount++;
 				last_score = SHAddScore(santa);
 				score += last_score;
-				
+
 				scoreDisplay.x = shot.x;
 				scoreDisplay.y = shot.y;
 				scoreDisplay.score = last_score;
 				scoreDisplay.rounds = 20;
 			}
-			
+
 			santa.x += santa.speed;
-			
+
 			scoreDisplay.rounds--;
-			
+
 			shot.y--;
 			if (shot.y == 0)
 				shot.fired = 0;
-			
+
 			if (hitcount == 10) {
 				hitcount = 0;
 				level++;
@@ -618,7 +613,7 @@ void santaHunta (void) {
 		}
 
 		count++;
-		
+
 		if ((input == KEY_RIGHT) || (input == keybindings.next)) {
 			if (gun_pos < COLS-5)
 				gun_pos++;
@@ -632,7 +627,7 @@ void santaHunta (void) {
 				mvaddstr (LINES-4, gun_pos-2, "\\***/");
 				attroff (COLOR_PAIR(12));
 				attroff (WA_BOLD);
-				
+
 				shot.x = gun_pos;
 				shot.y = LINES-4;
 				shot.fired = 1;
@@ -641,33 +636,33 @@ void santaHunta (void) {
 			SHFinalScore(score);
 			break;
 		}
-			
+
 		SHDrawGun(gun_pos);
 		SHDrawScore(score, level);
 		SHDrawStatus();
-		
+
 		refresh();
 	}
-	
+
 	/* Leave halfdelay mode. */
 	cbreak();
 }
 
 void UIAbout (void) {
 	int xpos;
-	
+
 	clear();				/* Get the crap off the screen to make room
 							   for our wonderful ASCII logo. :) */
 
 	xpos = COLS/2 - 40;
-	
+
 	if (COLS < 80) {
 		mvprintw (0, 0, _("Need at least 80 COLS terminal, sorry!"));
 		refresh();
 		getch();
 		return;
 	}
-	
+
 	if (easterEgg()) {
 		santaHunta();
 	} else {
@@ -679,7 +674,7 @@ void UIAbout (void) {
 		mvaddstr (6, xpos, "/______  / / ___|___/ \\____/  /__|__/  / ___|___/ \\____ \\   /__|__/  /______  /");
 		mvaddstr (7, xpos, "       \\/  \\/                          \\/              \\/                   \\/");
 		mvprintw (9, COLS/2-(strlen("Version")+strlen(VERSION)+1)/2, "Version %s", VERSION);
-		
+
 		mvaddstr (11, COLS/2-(strlen(_("Brought to you by:")))/2, _("Brought to you by:"));
 		mvaddstr (13, COLS/2-(strlen(_("Main code")))/2, _("Main code"));
 		mvaddstr (14, COLS/2-6, "Oliver Feiler");
@@ -690,7 +685,7 @@ void UIAbout (void) {
 		mvaddstr (21, COLS/2-32, "Fernando J. Pereda, Marco Cova, Cheng-Lung Sung, Dmitry Petukhov");
 		mvaddstr (22, COLS/2-26, "Douglas Campos, Ray Iwata, Piotr Ozarowski, Yang Huan");
 		mvaddstr (23, COLS/2-15, "Ihar Hrachyshka, Mats Berglund");
-		
+
 		refresh();
 		getch();
 	}

--- a/configure
+++ b/configure
@@ -12,7 +12,7 @@ my $xmlldflags = `xml2-config --libs`;
 chomp($xmlldflags);
 
 my $prefix = "/usr/local";
-my $cflags = "-Wall -Wno-format-y2k -O2 -DLOCALEPATH=\"\\\"\$(LOCALEPATH)\\\"\" -DOS=\\\"$os\\\" $xmlcflags \$(EXTRA_CFLAGS) ";
+my $cflags = "-Wall -Wextra -O2 -DLOCALEPATH=\"\\\"\$(LOCALEPATH)\\\"\" -DOS=\\\"$os\\\" $xmlcflags \$(EXTRA_CFLAGS) ";
 my $ldflags = "\$(EXTRA_LDFLAGS) -lncurses -lcrypto $xmlldflags ";
 
 my $use_nls = 1;

--- a/conversions.h
+++ b/conversions.h
@@ -30,11 +30,11 @@ char * iconvert (const char * inbuf);
 char * iconvert (char * inbuf);
 #endif
 char * UIDejunk (char * feed_description);
-char * WrapText (char * text, int width);
+char* WrapText (const char* text, unsigned width);
 char *base64encode(char const *inbuf, unsigned int inbuf_size);
 void CleanupString (char * string, int tidyness);
 char * Hashify (const char * url);
-char * genItemHash (char ** hashitems, int items);
+char* genItemHash (const char* const* hashitems, int items);
 int ISODateToUnix (char const * const ISODate);
 int pubDateToUnix (char const * const pubDate);
 char * unixToPostDateString (int unixDate);

--- a/digcalc.c
+++ b/digcalc.c
@@ -15,144 +15,87 @@
 #include "digcalc.h"
 #include <openssl/evp.h>
 
-
 /* calculate H(A1) as per spec */
-void DigestCalcHA1(
-    IN char * pszAlg,
-    IN char * pszUserName,
-    IN char * pszRealm,
-    IN char * pszPassword,
-    IN char * pszNonce,
-    IN char * pszCNonce,
-    OUT HASHHEX SessionKey
-    )
+void DigestCalcHA1 (const char* pszAlg, const char* pszUserName, const char* pszRealm,
+	const char* pszPassword, const char* pszNonce, const char* pszCNonce,
+	HASHHEX SessionKey)
 {
-	EVP_MD_CTX mdctx;
-	unsigned char md_value[EVP_MAX_MD_SIZE];
-	unsigned int md_len;
-	int i;
-	HASH HA1;
-	
-	EVP_DigestInit(&mdctx, EVP_md5());
-	EVP_DigestUpdate(&mdctx, pszUserName, strlen(pszUserName));
-	EVP_DigestUpdate(&mdctx, ":", 1);
-	EVP_DigestUpdate(&mdctx, pszRealm, strlen(pszRealm));
-	EVP_DigestUpdate(&mdctx, ":", 1);
-	EVP_DigestUpdate(&mdctx, pszPassword, strlen(pszPassword));
-	EVP_DigestFinal_ex(&mdctx, md_value, &md_len);
-	EVP_MD_CTX_cleanup(&mdctx);
-	
+	EVP_MD_CTX* mdctx = EVP_MD_CTX_new();
+	EVP_DigestInit (mdctx, EVP_md5());
+	EVP_DigestUpdate (mdctx, pszUserName, strlen(pszUserName));
+	EVP_DigestUpdate (mdctx, ":", 1);
+	EVP_DigestUpdate (mdctx, pszRealm, strlen(pszRealm));
+	EVP_DigestUpdate (mdctx, ":", 1);
+	EVP_DigestUpdate (mdctx, pszPassword, strlen(pszPassword));
+	unsigned char md_value [EVP_MAX_MD_SIZE];
+	unsigned md_len;
+	EVP_DigestFinal_ex (mdctx, md_value, &md_len);
+
 	if (strcmp(pszAlg, "md5-sess") == 0) {
-		EVP_DigestInit(&mdctx, EVP_md5());
-		EVP_DigestUpdate(&mdctx, HA1, HASHLEN);
-		EVP_DigestUpdate(&mdctx, ":", 1);
-		EVP_DigestUpdate(&mdctx, pszNonce, strlen(pszNonce));
-		EVP_DigestUpdate(&mdctx, ":", 1);
-		EVP_DigestUpdate(&mdctx, pszCNonce, strlen(pszCNonce));
-		EVP_DigestFinal_ex(&mdctx, md_value, &md_len);
-		EVP_MD_CTX_cleanup(&mdctx);
-	};
-	
-	for (i = 0; i < md_len; i++) {
-		sprintf(&SessionKey[2*i], "%02x", md_value[i]);
+		EVP_DigestInit (mdctx, EVP_md5());
+		HASH HA1;
+		EVP_DigestUpdate (mdctx, HA1, HASHLEN);
+		EVP_DigestUpdate (mdctx, ":", 1);
+		EVP_DigestUpdate (mdctx, pszNonce, strlen(pszNonce));
+		EVP_DigestUpdate (mdctx, ":", 1);
+		EVP_DigestUpdate (mdctx, pszCNonce, strlen(pszCNonce));
+		EVP_DigestFinal_ex (mdctx, md_value, &md_len);
 	}
+	EVP_MD_CTX_free (mdctx);
+
+	for (unsigned i = 0; i < md_len; ++i)
+		sprintf (&SessionKey[2*i], "%02x", md_value[i]);
 };
 
 /* calculate request-digest/response-digest as per HTTP Digest spec */
 void DigestCalcResponse(
-    IN HASHHEX HA1,           /* H(A1) */
-    IN char * pszNonce,       /* nonce from server */
-    IN char * pszNonceCount,  /* 8 hex digits */
-    IN char * pszCNonce,      /* client nonce */
-    IN char * pszQop,         /* qop-value: "", "auth", "auth-int" */
-    IN char * pszMethod,      /* method from the request */
-    IN char * pszDigestUri,   /* requested URL */
-    IN HASHHEX HEntity,       /* H(entity body) if qop="auth-int" */
-    OUT HASHHEX Response      /* request-digest or response-digest */
+    const HASHHEX HA1,		/* H(A1) */
+    const char* pszNonce,	/* nonce from server */
+    const char* pszNonceCount,	/* 8 hex digits */
+    const char* pszCNonce,	/* client nonce */
+    const char* pszQop,		/* qop-value: "", "auth", "auth-int" */
+    const char* pszMethod,	/* method from the request */
+    const char* pszDigestUri,	/* requested URL */
+    const HASHHEX HEntity,	/* H(entity body) if qop="auth-int" */
+    HASHHEX Response		/* request-digest or response-digest */
     )
 {
-	EVP_MD_CTX mdctx;
-	HASHHEX HA2Hex;
-	unsigned char md_value[EVP_MAX_MD_SIZE];
-	unsigned int md_len;
-	int i;
-	
 	/* calculate H(A2) */
-	EVP_DigestInit(&mdctx, EVP_md5());
-	EVP_DigestUpdate(&mdctx, pszMethod, strlen(pszMethod));
-	EVP_DigestUpdate(&mdctx, ":", 1);
-	EVP_DigestUpdate(&mdctx, pszDigestUri, strlen(pszDigestUri));
+	EVP_MD_CTX* mdctx = EVP_MD_CTX_new();
+	EVP_DigestInit (mdctx, EVP_md5());
+	EVP_DigestUpdate (mdctx, pszMethod, strlen(pszMethod));
+	EVP_DigestUpdate (mdctx, ":", 1);
+	EVP_DigestUpdate (mdctx, pszDigestUri, strlen(pszDigestUri));
 	if (strcmp(pszQop, "auth-int") == 0) {
-		EVP_DigestUpdate(&mdctx, ":", 1);
-		EVP_DigestUpdate(&mdctx, HEntity, HASHHEXLEN);
-	};
-	EVP_DigestFinal_ex(&mdctx, md_value, &md_len);
-	EVP_MD_CTX_cleanup(&mdctx);
-	
-	for (i = 0; i < md_len; i++) {
-		sprintf(&HA2Hex[2*i], "%02x", md_value[i]);
+		EVP_DigestUpdate (mdctx, ":", 1);
+		EVP_DigestUpdate (mdctx, HEntity, HASHHEXLEN);
 	}
-	
+	unsigned char md_value [EVP_MAX_MD_SIZE];
+	unsigned md_len = 0;
+	EVP_DigestFinal_ex (mdctx, md_value, &md_len);
+
+	HASHHEX HA2Hex;
+	for (unsigned i = 0; i < md_len; ++i)
+		sprintf (&HA2Hex[2*i], "%02x", md_value[i]);
+
 	/* calculate response */
-	EVP_DigestInit(&mdctx, EVP_md5());
-	EVP_DigestUpdate(&mdctx, HA1, HASHHEXLEN);
-	EVP_DigestUpdate(&mdctx, ":", 1);
-	EVP_DigestUpdate(&mdctx, pszNonce, strlen(pszNonce));
-	EVP_DigestUpdate(&mdctx, ":", 1);
+	EVP_DigestInit (mdctx, EVP_md5());
+	EVP_DigestUpdate (mdctx, HA1, HASHHEXLEN);
+	EVP_DigestUpdate (mdctx, ":", 1);
+	EVP_DigestUpdate (mdctx, pszNonce, strlen(pszNonce));
+	EVP_DigestUpdate (mdctx, ":", 1);
 	if (*pszQop) {
-		EVP_DigestUpdate(&mdctx, pszNonceCount, strlen(pszNonceCount));
-		EVP_DigestUpdate(&mdctx, ":", 1);
-		EVP_DigestUpdate(&mdctx, pszCNonce, strlen(pszCNonce));
-		EVP_DigestUpdate(&mdctx, ":", 1);
-		EVP_DigestUpdate(&mdctx, pszQop, strlen(pszQop));
-		EVP_DigestUpdate(&mdctx, ":", 1);
+		EVP_DigestUpdate (mdctx, pszNonceCount, strlen(pszNonceCount));
+		EVP_DigestUpdate (mdctx, ":", 1);
+		EVP_DigestUpdate (mdctx, pszCNonce, strlen(pszCNonce));
+		EVP_DigestUpdate (mdctx, ":", 1);
+		EVP_DigestUpdate (mdctx, pszQop, strlen(pszQop));
+		EVP_DigestUpdate (mdctx, ":", 1);
 	};
-	EVP_DigestUpdate(&mdctx, HA2Hex, HASHHEXLEN);
-	EVP_DigestFinal_ex(&mdctx, md_value, &md_len);
-	EVP_MD_CTX_cleanup(&mdctx);
-	
-	for (i = 0; i < md_len; i++) {
-		sprintf(&Response[2*i], "%02x", md_value[i]);
-	}
-	
-#if 0
-	/* This is the old MD5 digest calculator for a reference until I am sure
-	 * the new code works for sure */
-	/* *************************** */
-      struct MD5Context Md5Ctx;
-      HASH HA2;
-      HASH RespHash;
-      HASHHEX HA2Hex;
+	EVP_DigestUpdate (mdctx, HA2Hex, HASHHEXLEN);
+	EVP_DigestFinal_ex (mdctx, md_value, &md_len);
+	EVP_MD_CTX_free (mdctx);
 
-      /* calculate H(A2) */
-      MD5Init(&Md5Ctx);
-      MD5Update(&Md5Ctx, pszMethod, strlen(pszMethod));
-      MD5Update(&Md5Ctx, ":", 1);
-      MD5Update(&Md5Ctx, pszDigestUri, strlen(pszDigestUri));
-      if (strcmp(pszQop, "auth-int") == 0) {
-            MD5Update(&Md5Ctx, ":", 1);
-            MD5Update(&Md5Ctx, HEntity, HASHHEXLEN);
-      };
-      MD5Final(HA2, &Md5Ctx);
-       CvtHex(HA2, HA2Hex);
-
-      /* calculate response */
-      MD5Init(&Md5Ctx);
-      MD5Update(&Md5Ctx, HA1, HASHHEXLEN);
-      MD5Update(&Md5Ctx, ":", 1);
-      MD5Update(&Md5Ctx, pszNonce, strlen(pszNonce));
-      MD5Update(&Md5Ctx, ":", 1);
-      if (*pszQop) {
-
-          MD5Update(&Md5Ctx, pszNonceCount, strlen(pszNonceCount));
-          MD5Update(&Md5Ctx, ":", 1);
-          MD5Update(&Md5Ctx, pszCNonce, strlen(pszCNonce));
-          MD5Update(&Md5Ctx, ":", 1);
-          MD5Update(&Md5Ctx, pszQop, strlen(pszQop));
-          MD5Update(&Md5Ctx, ":", 1);
-      };
-      MD5Update(&Md5Ctx, HA2Hex, HASHHEXLEN);
-      MD5Final(RespHash, &Md5Ctx);
-      CvtHex(RespHash, Response);
-#endif
+	for (unsigned i = 0; i < md_len; ++i)
+		sprintf (&Response[2*i], "%02x", md_value[i]);
 };

--- a/digcalc.h
+++ b/digcalc.h
@@ -18,36 +18,23 @@
 typedef char HASH[HASHLEN];
 #define HASHHEXLEN 32
 typedef char HASHHEX[HASHHEXLEN+1];
-#define IN
-#define OUT
 
 /* calculate H(A1) as per HTTP Digest spec */
-void DigestCalcHA1(
-    IN char * pszAlg,
-    IN char * pszUserName,
-    IN char * pszRealm,
-    IN char * pszPassword,
-    IN char * pszNonce,
-    IN char * pszCNonce,
-    OUT HASHHEX SessionKey
-    );
+void DigestCalcHA1 (const char* pszAlg, const char* pszUserName, const char* pszRealm,
+			const char* pszPassword, const char* pszNonce, const char* pszCNonce,
+			HASHHEX SessionKey);
 
 /* calculate request-digest/response-digest as per HTTP Digest spec */
-void DigestCalcResponse(
-    IN HASHHEX HA1,           /* H(A1) */
-    IN char * pszNonce,       /* nonce from server */
-    IN char * pszNonceCount,  /* 8 hex digits */
-    IN char * pszCNonce,      /* client nonce */
-    IN char * pszQop,         /* qop-value: "", "auth", "auth-int" */
-    IN char * pszMethod,      /* method from the request */
-    IN char * pszDigestUri,   /* requested URL */
-    IN HASHHEX HEntity,       /* H(entity body) if qop="auth-int" */
-    OUT HASHHEX Response      /* request-digest or response-digest */
-    );
-
-void CvtHex(
-    IN HASH Bin,
-    OUT HASHHEX Hex
+void DigestCalcResponse (
+    const HASHHEX HA1,		/* H(A1) */
+    const char* pszNonce,	/* nonce from server */
+    const char* pszNonceCount,	/* 8 hex digits */
+    const char* pszCNonce,	/* client nonce */
+    const char* pszQop,		/* qop-value: "", "auth", "auth-int" */
+    const char* pszMethod,	/* method from the request */
+    const char* pszDigestUri,	/* requested URL */
+    const HASHHEX HEntity,	/* H(entity body) if qop="auth-int" */
+    HASHHEX Response		/* request-digest or response-digest */
     );
 
 #endif

--- a/interface.c
+++ b/interface.c
@@ -67,7 +67,7 @@ struct scrolltext {
 };
 
 #ifdef SIGWINCH
-void sig_winch(int p)
+void sig_winch (int p __attribute__((unused)))
 {
 	resize_dirty = 1;
 }

--- a/main.c
+++ b/main.c
@@ -155,15 +155,9 @@ void MainSignalHandler (int sig) {
 }
 
 /* Automatic child reaper. */
-void sigChildHandler (int sig) {
-	int status, child_val;
-
+static void sigChildHandler (int sig __attribute__((unused))) {
 	/* Wait for any child without blocking */
-	if (waitpid(-1, &status, WNOHANG) < 0)
-			return;
-
-	if (WIFEXITED(status))
-		child_val = WEXITSTATUS(status);
+	waitpid (-1, NULL, WNOHANG);
 }
 
 void printHelp (void) {

--- a/netio.c
+++ b/netio.c
@@ -129,7 +129,7 @@ int NetPoll (struct feed * cur_ptr, int * my_socket, int rw) {
  *	0	Connected
  *	-1	Error occured (netio_error is set)
  */
-int NetConnect (int * my_socket, char * host, struct feed * cur_ptr, int httpproto, int suppressoutput) {
+int NetConnect (int * my_socket, char * host, struct feed * cur_ptr, int httpproto __attribute__((unused)), int suppressoutput) {
 	char tmp[512];
 	struct sockaddr_in address;	
 	struct hostent *remotehost;

--- a/os-support.c
+++ b/os-support.c
@@ -39,7 +39,7 @@
  * The following function was written by François Gouget.
  */
 #ifdef SUN
-char* strsep(char** str, const char* delims)
+char* strsep (char** str, const char* delims)
 {
     char* token;
 
@@ -93,29 +93,21 @@ time_t timegm(struct tm *t)
 #endif
 
 /* strcasestr stolen from: http://www.unixpapa.com/incnote/string.html */
-char *s_strcasestr(char *a, char *b) {
-	size_t l;
+const char* s_strcasestr (const char* a, const char* b) {
+	const size_t lena = strlen(a), lenb = strlen(b);
 	char f[3];
-	int lena = strlen(a);
-	int lenb = strlen(b);
-	
 	snprintf(f, sizeof(f), "%c%c", tolower(*b), toupper(*b));
-	for (l = strcspn(a, f); l != lena; l += strcspn(a + l + 1, f) + 1)
+	for (size_t l = strcspn(a, f); l != lena; l += strcspn(a + l + 1, f) + 1)
 		if (strncasecmp(a + l, b, lenb) == 0)
-			return(a + l);
-	return(NULL);
+			return a + l;
+	return NULL;
 }
 
 
 /* Private malloc wrapper. Aborts program execution if malloc fails. */
-void * s_malloc (size_t size) {
-	void *newmem;
-	
-	newmem = malloc (size);
-	
-	if (newmem == NULL) {
+void* s_malloc (size_t size) {
+	void* newmem = malloc (size);
+	if (!newmem)
 		MainQuit ("Allocating memory", strerror(errno));
-	}
-	
 	return newmem;
 }

--- a/os-support.h
+++ b/os-support.h
@@ -27,10 +27,10 @@
 #define OS_SUPPORT_H
 
 #ifdef SUN
-char* strsep(char** str, const char* delims);
+char* strsep (char** str, const char* delims);
 #endif
 
-char *s_strcasestr(char *a, char *b);
-void * s_malloc (size_t size);
+const char* s_strcasestr (const char* a, const char* b);
+void* s_malloc (size_t size);
 
 #endif

--- a/ui-support.c
+++ b/ui-support.c
@@ -223,7 +223,7 @@ void UISupportDrawHeader (const char * headerstring) {
 	
 	mvprintw (0, 1, "* Snownews %s", VERSION);
 	if (headerstring != NULL) {
-		if (strlen(headerstring) > COLS-18)
+		if (strlen(headerstring) > COLS-18u)
 			mvaddnstr (0, 19, headerstring, COLS-20);
 		else
 			mvaddstr (0, COLS-strlen(headerstring)-1, headerstring);

--- a/updatecheck.c
+++ b/updatecheck.c
@@ -45,7 +45,6 @@ void AutoVersionCheck (void) {
 	int oldtime;
 	char *versionstring = NULL;
 	char *url;
-	char *freeme;
 	
 	update = newFeedStruct();
 	
@@ -77,7 +76,6 @@ void AutoVersionCheck (void) {
 	
 	url = strdup ("http://kiza.kcore.de/software/snownews/version");
 	update->feedurl = strdup(url);
-	freeme = url;
 	versionstring = DownloadFeed (url, update, 1);
 	free (url);
 	

--- a/xmlparse.c
+++ b/xmlparse.c
@@ -183,7 +183,6 @@ void parse_rdf10_item(struct feed *feed, xmlDocPtr doc, xmlNodePtr node)
 {
 	xmlNodePtr cur;
 	xmlChar *readstatusstring;
-	char **hashitems = NULL;
 	char *guid = NULL;
 	char *date_str = NULL;
 	struct newsitem *item;
@@ -277,14 +276,9 @@ void parse_rdf10_item(struct feed *feed, xmlDocPtr doc, xmlNodePtr node)
 	   <guid> is not saved in the cache, thus we would generate a different
 	   hash than the one from the live feed. */
 	if (item->data->hash == NULL) {
-		hashitems = malloc (sizeof(char *) * 4);
-		hashitems[0] = item->data->title;
-		hashitems[1] = item->data->link;
-		hashitems[2] = guid;
-		hashitems[3] = NULL;
+		const char* hashitems[] = { item->data->title, item->data->link, guid, NULL };
 		item->data->hash = genItemHash (hashitems, 3);
 		xmlFree (guid);
-		free (hashitems);
 	}
 	
 	/* If saverestore == 1, restore readstatus. */

--- a/zlib_interface.h
+++ b/zlib_interface.h
@@ -32,8 +32,6 @@ enum JG_ZLIB_ERROR {
 	JG_ZLIB_ERROR_BAD_FLAGS = -6
 };
 
-extern int JG_ZLIB_DEBUG;
-
 int jg_zlib_uncompress(void const *in_buf, int in_size, 
                        void **out_buf_ptr, int *out_size,
                        int gzip);   


### PR DESCRIPTION
Fix openssl MD5 hash calculations; context struct is private and must be created with helper functions. Add -Wextra to compile flags and fix all warnings; that includes const correctness, signed/unsigned comparisons, and unused variables and parameters.