### PR TITLE
Build system improvements.

### DIFF
--- a/Config.mk.in
+++ b/Config.mk.in
@@ -1,39 +1,39 @@
 ################ Package information #################################
 
-NAME		:= @PKG_NAME@
-VERSION		:= @PKG_VERSION@
-
-#DEBUG		:= 1
+name		:= @pkg_name@
+version		:= @pkg_verstr@
 
 ################ Programs ############################################
 
 CC		:= @CC@
 MSGFMT		:= @MSGFMT@
 INSTALL		:= @INSTALL@
-
-INSTALLEXE	:= ${INSTALL} -D -p -m 755 -s
-INSTALLSCR	:= ${INSTALL} -D -p -m 755
-INSTALLDATA	:= ${INSTALL} -D -p -m 644
+INSTALL_DATA	:= ${INSTALL} -m 644
+INSTALL_PROGRAM	:= ${INSTALL} -m 755
 
 ################ Destination #########################################
 
-PREFIX		:= @prefix@
-BINDIR		:= @bindir@
-LOCALEPATH	:= @localedir@
-MANPATH		:= @mandir@
-BUILDDIR	:= @builddir@/${NAME}
-PKGDIR		:= @pkgdir@
+prefix		:= @prefix@
+bindir		:= @bindir@
+datadir		:= @datadir@
+mandir		:= @mandir@
+man1dir		:= @man1dir@
+localedir	:= @localedir@
+TMPDIR		:= @TMPDIR@
+builddir	:= @builddir@/${name}
 O		:= .o/
 
 ################ Compiler options ####################################
 
-CFLAGS		:= -Wall -Wextra -Wredundant-decls -Wshadow \
-		   -std=c11 -I/usr/include/libxml2
-LDFLAGS		:= -liconv -lintl -lxml2 -lncurses -lz
-ifdef DEBUG
-    CFLAGS	+= -O0 -ggdb3
-    LDFLAGS	+= -g -rdynamic
+#debug		:= 1
+libs		:= @pkg_libs@ -liconv -lintl
+ifdef debug
+    cflags	:= -O0 -ggdb3
+    ldflags	:= -g -rdynamic
 else
-    CFLAGS	+= -Os -g0 -DNDEBUG=1
-    LDFLAGS	+= -s
+    cflags	:= -Os -g0 -DNDEBUG=1
+    ldflags	:= -s
 endif
+CFLAGS		:= -Wall -Wextra -Wredundant-decls -Wshadow
+cflags		+= -std=c11 @pkg_cflags@ ${CFLAGS}
+ldflags		+= @pkg_ldflags@ ${LDFLAGS}

--- a/Makefile
+++ b/Makefile
@@ -1,141 +1,147 @@
-include Config.mk
+-include Config.mk
 
 ################ Source files ##########################################
 
-EXE	:= $O${NAME}
-SRCS	:= $(wildcard *.c)
-OBJS	:= $(addprefix $O,$(SRCS:.c=.o))
-DEPS	:= ${OBJS:.o=.d}
-CONFS	:= Config.mk config.h
-ONAME   := $(notdir $(abspath $O))
+exe	:= $O${name}
+srcs	:= $(wildcard *.c)
+objs	:= $(addprefix $O,$(srcs:.c=.o))
+deps	:= ${objs:.o=.d}
+confs	:= Config.mk config.h
+oname   := $(notdir $(abspath $O))
 
 ################ Compilation ###########################################
 
+.SUFFIXES:
 .PHONY:	all run
 
-all:	${EXE}
+all:	${exe}
 
-run:	${EXE}
-	@${EXE}
+run:	${exe}
+	@${exe}
 
-${EXE}:	${OBJS}
+${exe}:	${objs}
 	@echo "Linking $@ ..."
-	@${CC} -o $@ $^ ${LDFLAGS}
+	@${CC} ${ldflags} -o $@ $^ ${libs}
 
-${EXE}-static: ${SRCS}
-	${CC} -s -static -o $@ ${CFLAGS} ${SRCS} ${LDFLAGS}
+${exe}-static: ${srcs}
+	@echo "Statically linking $@ ..."
+	@${CC} ${cflags} ${ldflags} -s -static -o $@ $^
 
 $O%.o:	%.c
 	@echo "    Compiling $< ..."
-	@${CC} ${CFLAGS} -MMD -MT "$(<:.c=.s) $@" -o $@ -c $<
+	@${CC} ${cflags} -MMD -MT "$(<:.c=.s) $@" -o $@ -c $<
 
 %.s:	%.c
 	@echo "    Compiling $< to assembly ..."
-	@${CC} ${CFLAGS} -S -o $@ -c $<
+	@${CC} ${cflags} -S -o $@ -c $<
 
 include man/Module.mk
 include po/Module.mk
 
 ################ Installation ##########################################
-ifdef BINDIR
 
-.PHONY:	install uninstall install-bin uninstall-bin
+ifdef bindir
+.PHONY:	install installdirs uninstall uninstall-bin
 
-EXEI	:= ${BINDIR}/$(notdir ${EXE})
-O2SI	:= ${BINDIR}/opml2snow
-S2OI	:= ${BINDIR}/snow2opml
+exed	:= ${DESTDIR}${bindir}
+exei	:= ${exed}/$(notdir ${exe})
+o2si	:= ${exed}/opml2snow
+s2oi	:= ${exed}/snow2opml
 
-install:	install-bin
-install-bin:	${EXEI} ${O2SI} ${S2OI}
-
-${EXEI}:	${EXE}
+${exed}:
+	@echo "Creating $@ ..."
+	@${INSTALL} -d $@
+${exei}:	${exe} | ${exed}
 	@echo "Installing $@ ..."
-	@${INSTALLEXE} $< $@
-${O2SI}:	opml2snow
+	@${INSTALL_PROGRAM} $< $@
+${o2si}:	opml2snow | ${exed}
 	@echo "Installing $@ ..."
-	@${INSTALLSCR} $< $@
-${S2OI}:	${O2SI}
+	@${INSTALL_PROGRAM} $< $@
+${s2oi}:	${o2si} | ${exed}
 	@echo "Installing $@ ..."
-	@(cd ${BINDIR}; rm -f $@; ln -s $(notdir $<) $(notdir $@))
+	@(cd ${exed}; rm -f $@; ln -s $(notdir $<) $(notdir $@))
 
+installdirs:	${exed}
+install:	${exei} ${o2si} ${s2oi}
 uninstall:	uninstall-bin
 uninstall-bin:
-	@if [ -f ${EXEI} ]; then\
-	    echo "Uninstalling ${EXEI} ...";\
-	    rm -f ${EXEI} ${O2SI} ${S2OI};\
+	@if [ -f ${exei} ]; then\
+	    echo "Removing ${exei} ...";\
+	    rm -f ${exei} ${o2si} ${s2oi};\
 	fi
-
 endif
+
 ################ Maintenance ###########################################
 
-.PHONY:	clean distclean maintainer-clean dist dist-binary
+.PHONY:	clean distclean maintainer-clean
 
 clean:
-	@if [ -h ${ONAME} ]; then\
-	    rm -f ${EXE} ${EXE}-static ${OBJS} ${DEPS} $O.d ${ONAME};\
-	    rmdir ${BUILDDIR};\
+	@if [ -d ${builddir} ]; then\
+	    rm -f ${exe} ${exe}-static ${objs} ${deps} $O.d;\
+	    rmdir ${builddir};\
 	fi
 
 distclean:	clean
-	@rm -f ${CONFS} config.status
+	@rm -f ${oname} ${confs} config.status
 
 maintainer-clean: distclean
 
-$O.d:	${BUILDDIR}/.d
-	@[ -h ${ONAME} ] || ln -sf ${BUILDDIR} ${ONAME}
+$O.d:	${builddir}/.d
+	@[ -h ${oname} ] || ln -sf ${builddir} ${oname}
 $O%/.d:	$O.d
 	@[ -d $(dir $@) ] || mkdir $(dir $@)
 	@touch $@
-${BUILDDIR}/.d:	Makefile
+${builddir}/.d:	Makefile
 	@[ -d $(dir $@) ] || mkdir -p $(dir $@)
 	@touch $@
 
 Config.mk:	Config.mk.in
 config.h:	config.h.in
-${OBJS}:	Makefile ${CONFS} $O.d
-${CONFS}:	configure
+${objs}:	Makefile ${confs} | $O.d
+${confs}:	configure
 	@if [ -x config.status ]; then echo "Reconfiguring ...";\
 	    ./config.status;\
 	else echo "Running configure ...";\
 	    ./configure;\
 	fi
 
--include ${DEPS}
+-include ${deps}
 
 ################ Dist ##################################################
 
 .PHONY:	dist dist-binary
 
-DISTDIR		:= ${NAME}-${VERSION}
-DISTFILES	:= AUTHOR COPYING CREDITS Changelog README README.de README.patching opml2snow \
-	Makefile configure doc po scripts ${SRCS} $(wildcard *.h) config.h
+distdir		:= ${name}-${version}
+distfiles	:= AUTHOR COPYING CREDITS Changelog README README.de README.patching opml2snow \
+	Makefile configure doc po scripts ${srcs} $(wildcard *.h) config.h
 
 dist: clean
 	./configure
-	mkdir ${DISTDIR}
-	cp -R ${DISTFILES} ${DISTDIR}
-	tar -czf ${DISTDIR}.tar.gz ${DISTDIR}
-	rm -rf ${DISTDIR}
+	mkdir ${distdir}
+	cp -R ${distfiles} ${distdir}
+	tar -czf ${distdir}.tar.gz ${distdir}
+	rm -rf ${distdir}
 
-dist-binary: clean ${EXE}-static
-	DISTDIR=${NAME}-i386-${VERSION}
-	mkdir ${DISTDIR}
-	mkdir ${DISTDIR}/man
-	mkdir ${DISTDIR}/man/de
-	mkdir ${DISTDIR}/man/nl
-	mkdir ${DISTDIR}/man/fr
-	mkdir ${DISTDIR}/man/it
-	mkdir ${DISTDIR}/man/ru_RU.KOI8-R
-	mkdir ${DISTDIR}/po
-	cp AUTHOR COPYING CREDITS Changelog README README.de scripts/INSTALL.binary opml2snow ${DISTDIR}
-	cp ${EXE}-static ${DISTDIR}/${NAME}
-	cp doc/man/de/${NAME}.1 ${DISTDIR}/man/de
-	cp doc/man/nl/${NAME}.1 ${DISTDIR}/man/nl
-	cp doc/man/fr/${NAME}.1 ${DISTDIR}/man/fr
-	cp doc/man/it/${NAME}.1 ${DISTDIR}/man/it
-	cp doc/man/ru_RU.KOI8-R/${NAME}.1 ${DISTDIR}/man/ru_RU.KOI8-R
-	cp doc/man/${NAME}.1 ${DISTDIR}/man
-	cp po/*.mo ${DISTDIR}/po
-	cp scripts/install.sh ${DISTDIR}
-	tar -cjf ${DISTDIR}.i386.tar.bz2 ${DISTDIR}
-	rm -rf ${DISTDIR}
+dist-binary: clean ${exe}-static
+	arch=`uname -m`
+	distdir=${name}-${arch}-${version}
+	mkdir ${distdir}
+	mkdir ${distdir}/man
+	mkdir ${distdir}/man/de
+	mkdir ${distdir}/man/nl
+	mkdir ${distdir}/man/fr
+	mkdir ${distdir}/man/it
+	mkdir ${distdir}/man/ru_RU.KOI8-R
+	mkdir ${distdir}/po
+	cp AUTHOR COPYING CREDITS Changelog README README.de scripts/INSTALL.binary opml2snow ${distdir}
+	cp ${exe}-static ${distdir}/${name}
+	cp doc/man/de/${name}.1 ${distdir}/man/de
+	cp doc/man/nl/${name}.1 ${distdir}/man/nl
+	cp doc/man/fr/${name}.1 ${distdir}/man/fr
+	cp doc/man/it/${name}.1 ${distdir}/man/it
+	cp doc/man/ru_RU.KOI8-R/${name}.1 ${distdir}/man/ru_RU.KOI8-R
+	cp doc/man/${name}.1 ${distdir}/man
+	cp po/*.mo ${distdir}/po
+	cp scripts/install.sh ${distdir}
+	tar -cjf ${distdir}.${arch}.tar.bz2 ${distdir}
+	rm -rf ${distdir}

--- a/config.h.in
+++ b/config.h.in
@@ -17,16 +17,16 @@
 #pragma once
 
 // Define to the one symbol short name of this package
-#define @PKG_UNAME@_NAME		"@PKG_NAME@"
+#define @pkg_uname@_NAME		"@pkg_name@"
 // Define to the version of this package
-#define @PKG_UNAME@_VERSION	"@PKG_VERSION@"
+#define @pkg_uname@_VERSION	"@pkg_version@"
 // Define to the version string of this package
-#define @PKG_UNAME@_VERSTRING	"@PKG_VERSTR@"
+#define @pkg_uname@_VERSTRING	"@pkg_verstr@"
 // Define to the address where bug reports for this package should be sent
-#define @PKG_UNAME@_BUGREPORT	"@PKG_BUGREPORT@"
+#define @pkg_uname@_BUGREPORT	"@pkg_bugreport@"
 
 // Define to the value of LOCALEPATH environment variable
-#define LOCALEPATH	"@localedir@"
+#define LOCALEPATH		"@localepath@"
 
 // Snownews configuration files directory, starts with %s for $HOME
 #define SNOWNEWS_CONFIG_DIR	"%s/.snownews/"

--- a/configure
+++ b/configure
@@ -3,17 +3,15 @@
 # Project Configuration						     #
 ######################################################################
 
-PKG_NAME="snownews"
-PKG_VERSTR="v1.6.0"
-
-MNT_NAME="Oliver Feiler"
-MNT_MAIL="kiza@kcore.de"
+pkg_name="snownews"
+pkg_verstr="v1.6.0"
+pkg_bugreport="Oliver Feiler <kiza@kcore.de>"
 
 # Files that get created by this script
-FILES="Config.mk config.h"
+files="Config.mk config.h"
 
 # Package options
-COMPONENTS="
+components="
 {
 name=[with-debug]
 desc=[	Compile for debugging]
@@ -25,7 +23,7 @@ seds=[s/ -std=c/ -march=native -std=c/]
 }{
 name=[without-nls]
 desc=[	Disable translations]
-seds=[s/^#define \(LOCALEPATH\)/#undef \1 \/\/ /;s/^\(LOCALEPATH\)/#\1/;s/ -lintl//]
+seds=[s/^#define \(LOCALEPATH\)/#undef \1 \/\/ /;s/^\(localedir\)/#\1/;s/ -lintl//]
 }{
 name=[with-experimental]
 desc=[Enable experimental code]
@@ -33,32 +31,33 @@ seds=[s/^#undef \(USE_UNSUPPORTED_AND_BROKEN_CODE\)/#define \1/]
 }";
 
 # First pair is used if nothing matches
-PROGS="CC=gcc CC=clang INSTALL=install MSGFMT=msgfmt"
+progs="CC=gcc CC=clang CC=cc INSTALL=install MSGFMT=msgfmt"
 
 # Libs found using pkg-config
-LIBS="libxml-2.0 ncurses zlib"
-# Defaults to substitute with pkg-config --libs output
-DEFLIBS="-lxml2 -lncursesw -lz"
-# Defaults to substitute with pkg-config --cflags output
-DEFINCS="-I\/usr\/include\/libxml2"
+pkgs="libxml-2.0 ncurses zlib"
+# Default pkg flags to substitute when pkg-config is not found
+pkg_libs="-lxml2 -lncursesw -lz"
+pkg_cflags="-I\/usr\/include\/libxml2"
+pkg_ldflags=""
 
 # Automatic vars
-[ -d .git ] && PKG_VERSTR=`git describe --tags --always`
-PKG_MAJOR=`expr "$PKG_VERSTR" : 'v\([0-9]*\)\.[0-9]*\.[0-9]*'`
-PKG_MINOR=`expr "$PKG_VERSTR" : 'v[0-9]*\.\([0-9]*\)\.[0-9]*'`
-PKG_BUILD=`expr "$PKG_VERSTR" : 'v[0-9]*\.[0-9]*\.\([0-9]*\)'`
-PKG_STRING="$PKG_NAME $PKG_VERSTR"
-PKG_BUGREPORT="$MNT_NAME <$MNT_MAIL>"
+if [ -d .git ]; then
+    pkg_vverstr=$(expr $(git describe --always) : '\(v[0-9]*\.[0-9]*\)')
+    [ -z "$pkg_vverstr" ] || pkg_verstr=$pkg_vverstr
+fi
+pkg_major=`expr "$pkg_verstr" : 'v\([0-9]*\)\.[0-9]*'`
+pkg_minor=`expr "$pkg_verstr" : 'v[0-9]*\.\([0-9]*\)'`
+pkg_string="$pkg_name $pkg_verstr"
 
 # Miscellaneous substitutions
-CUSTSUBS="s/@PKG_NAME@/$PKG_NAME/g
-s/@PKG_VERSION@/$PKG_MAJOR.$PKG_MINOR.$PKG_BUILD/g
-s/@PKG_VERSTR@/$PKG_VERSTR/g
-s/@PKG_STRING@/$PKG_STRING/g
-s/@PKG_UNAME@/`echo $PKG_NAME|tr a-z A-Z`/g
-s/@PKG_BUGREPORT@/$PKG_BUGREPORT/g
-s/@PKG_MAJOR@/$PKG_MAJOR/g
-s/@PKG_MINOR@/$PKG_MINOR/g"
+custsubs="s/@pkg_name@/$pkg_name/g
+s/@pkg_version@/0x$pkg_major$pkg_minor/g
+s/@pkg_verstr@/$pkg_verstr/g
+s/@pkg_string@/$pkg_string/g
+s/@pkg_uname@/`echo $pkg_name|tr a-z A-Z`/g
+s/@pkg_bugreport@/$pkg_bugreport/g
+s/@pkg_major@/$pkg_major/g
+s/@pkg_minor@/$pkg_minor/g"
 
 ######################################################################
 # The rest of the file is configuration code. Leave it alone.	     #
@@ -80,16 +79,16 @@ esac
 
 sub "s/^#undef \(OS\)/#define \1 \"$SYSNAME\"/"
 if [ "$SYSNAME" = "linux" ]; then
-    sub "s/ -liconv//;s/ -lintl//"
+    sub "s/ -liconv -lintl//"
 elif [ "$SYSNAME" = "sun" ]; then
     sub "s/^#undef \(SUN\)/#define \1 1/"
 fi
 
 #### Printing helper functions #######################################
 
-PrintComponents() {
+print_components() {
     local cc name desc
-    cc=$COMPONENTS
+    cc=$components
     echo "Options:"
     while [ ! -z "$cc" ]; do
 	name=`expr "$cc" : '[^}]*name=\[\([^]]*\)\]'`
@@ -100,40 +99,40 @@ PrintComponents() {
     echo
 }
 
-PrintHelp() {
-    echo "This program configures $PKG_STRING for many kinds of systems.
+print_help() {
+    echo "This program configures $pkg_string build system.
 
-Usage: configure [OPTION]...
+Usage: configure [option]...
 
 Configuration:
   -h, --help		display this help and exit
   -V, --version		display version information and exit
 
 Installation directories:
-  --prefix=PREFIX	architecture-independent files [/usr/local]
-  --mandir=DIR		manual pages [PREFIX/share/man]
-  --localedir=DIR	localization files [PREFIX/share/locale]
-  --builddir=DIR	location for compiled objects [/tmp/$USER/make]
-  --pkgdir=DIR		package tree root []
+  --prefix=dir		architecture-independent files [/usr/local]
+  --datadir=dir		architecture-independent data dir [prefix/share]
+  --mandir=dir		manual pages [datadir/man]
+  --localedir=dir	localization files [datadir/locale]
+  --builddir=dir	location for compiled objects [\$TMPDIR/make]
 "
-    PrintComponents
-    echo "Report bugs to $PKG_BUGREPORT."
+    print_components
+    echo "Report bugs to $pkg_bugreport."
 }
 
-PrintVersion() {
-    echo "$PKG_NAME configure $PKG_VERSTR"
+print_version() {
+    echo "$pkg_name $pkg_verstr configure"
 }
 
-SubVar() {
+sub_var() {
     local esc2
     esc2=`escpath $2`
     eval ac_var_$1='$esc2';
     sub "s/@$1@/$esc2/g"
 }
 
-SubComp() {
+sub_comp() {
     local cc name seds
-    cc=$COMPONENTS
+    cc=$components
     while [ ! -z "$cc" ]; do
 	name=`expr "$cc" : '[^}]*name=\[\([^]]*\)\]'`
 	seds=`expr "$cc" : '[^}]*seds=\[\([^]]*\)\]'`
@@ -145,10 +144,10 @@ SubComp() {
 for i in $*; do
     case $i in
 	--)		break;;
-	--version |-V)	PrintVersion && die;;
-	--help |-h |-?)	PrintHelp && die;;
-	--*=*)		SubVar `expr "$i" : '--\([^=]*\)='` `expr "$i" : '[^=]*=\(.*\)'`;;
-	--*)		SubComp `expr "$i" : '--\(.*\)'`;;
+	--version |-V)	print_version && die;;
+	--help |-h |-?)	print_help && die;;
+	--*=*)		sub_var `expr -- "$i" : '--\([^=]*\)='` `expr -- "$i" : '[^=]*=\(.*\)'`;;
+	--*)		sub_comp `expr -- "$i" : '--\(.*\)'`;;
 	*)		echo "Error: unrecognized option \"$i\"" && die;;
     esac
 done
@@ -156,26 +155,19 @@ done
 #### Set directory prefixes ##########################################
 
 sub "s/@prefix@/${ac_var_prefix:=\/usr\/local}/g
-s/@bindir@/${ac_var_bindir:=$ac_var_prefix\/bin}/g
-s/@mandir@/${ac_var_mandir:=$ac_var_prefix\/share\/man}/g
-s/@localedir@/${ac_var_localedir:=$ac_var_prefix\/share\/locale}/g
-s/@builddir@/\/tmp\/$USER\/make/g
-s/@pkgdir@//g"
-
-# Replace prefix variables, where available
-if [ "$ac_var_bindir" = "$ac_var_prefix\/bin" ]; then
-    sub "s/$ac_var_bindir/\${PREFIX}\/bin/";
-fi
-if [ "$ac_var_mandir" = "$ac_var_prefix\/share\/man" ]; then
-    sub "s/$ac_var_mandir/\${PREFIX}\/share\/man/";
-fi
-if [ "$ac_var_localedir" = "$ac_var_prefix\/share\/locale" ]; then
-    sub "s/ $ac_var_localedir/ \${PREFIX}\/share\/locale/";
-fi
+s/@bindir@/${ac_var_bindir:=\$\{prefix\}\/bin}/g
+s/@datadir@/${ac_var_datadir:=\$\{prefix\}\/share}/g
+s/@mandir@/${ac_var_mandir:=\$\{datadir\}\/man}/g
+s/@man1dir@/${ac_var_man1dir:=\$\{mandir\}\/man1}/g
+s/@localedir@/${ac_var_localedir:=\$\{datadir\}\/locale}/g
+s/@localepath@/${ac_var_prefix}\/share\/locale/g
+s/@TMPDIR@/$(escpath ${TMPDIR:-/tmp})/g
+s/@builddir@/\$\{TMPDIR\}\/make/g"
 
 #### Find programs and libs ##########################################
 
-for i in $PROGS; do
+# Programs found using which
+for i in $progs; do
     pname=`expr "$i" : '\([^=]*\)=[^=]*'`
     pcall=`expr "$i" : '[^=]*=\([^=]*\)'`
     ppath=`eval echo \$\{$pname\}`
@@ -183,41 +175,39 @@ for i in $PROGS; do
     # First check if an environment variable is set
     [ ! -z "$ppath" ] && sub "s/@$pname@/$ppath/g"
     # Check if the program exists
-    [ -x `which $pcall 2>/dev/null` ] && sub "s/@$pname@/$pcall/g"
+    ppath=`which $pcall 2>/dev/null`
+    [ ! -z "$ppath" -a -x "$ppath" ] && sub "s/@$pname@/$pcall/g"
 done
-# If nothing found in first loop, set the first pair anyway.
-for i in $PROGS; do
+# If nothing found in first loop, set the first pair anyway
+for i in $progs; do
     pname=`expr "$i" : '\([^=]*\)=[^=]*'`
     pcall=`expr "$i" : '[^=]*=\([^=]*\)'`
     sub "s/@$pname@/$pcall/g"
 done
-# And, finally, the environment variables
-for i in $ENVIRONS; do
-    esciv="`eval echo '"'\$\{$i\}'"'|sed 's/\//\\\&/g'`"
-    ppath=`eval echo \$\{$pname\}`
-    ppath=`escpath "$ppath"`
-    [ ! -z "$ppath" ] && ppath=" $ppath"
-    sub "s/ @$i@/$ppath/g"
-done
 
-sub "$CUSTSUBS"
-
-# If pkg-config is installed, the defaults can be checked
-PKGCONFIG=`which pkg-config 2>/dev/null`
-if [ -x $PKGCONFIG ]; then
-    for l in $LIBS; do
-	if ! $PKGCONFIG --exists $l; then
-	    echo "required library $l is missing";
-	    die;
-	fi
+# Packages found using pkg-config
+pkgconfig=`which pkg-config 2>/dev/null`
+if [ ! -z "$pkgconfig" -a -x "$pkgconfig" ]; then
+    faildeps=""
+    for i in $pkgs; do
+	`$pkgconfig --exists $i` || faildeps="$i $faildeps"
     done
-    sub "s/$DEFLIBS/$(escpath $($PKGCONFIG --libs $LIBS))/"
-    sub "s/$DEFINCS/$(escpath $($PKGCONFIG --cflags $LIBS))/"
+    if [ ! -z "$faildeps" ]; then
+	echo "Error: missing required packages: $faildeps"; die
+    fi
+    pkg_cflags=$(escpath "$($pkgconfig --cflags $pkgs)")
+    pkg_libs=$(escpath "$($pkgconfig --libs-only-l $pkgs)")
+    pkg_ldflags=$(escpath "$($pkgconfig --libs-only-L --libs-only-other $pkgs)")
 fi
+sub "s/@pkg_cflags@/$pkg_cflags/"
+sub "s/@pkg_libs@/$pkg_libs/"
+sub "s/@pkg_ldflags@/$pkg_ldflags/"
+
+sub "$custsubs"
 
 #### Apply substitutions to all files ################################
 
-for i in $FILES; do
+for i in $files; do
     sed -f config.sed $i.in > $i
 done
 

--- a/man/Module.mk
+++ b/man/Module.mk
@@ -1,36 +1,47 @@
 ################ Source files ##########################################
 
-man/LMANS	:= $(wildcard man/snownews.*.1)
-man/MANS	:= $(filter-out ${man/LMANS},$(wildcard man/*.1))
-man/LANGS	:= $(subst man/snownews.,,$(man/LMANS:.1=))
+man/lmans	:= $(wildcard man/snownews.*.1)
+man/mans	:= $(filter-out ${man/lmans},$(wildcard man/*.1))
+man/langs	:= $(subst man/snownews.,,$(man/lmans:.1=))
 
 ################ Installation ##########################################
-ifdef MANPATH
+ifdef man1dir
 .PHONY:	man/install man/uninstall
 
-man/IPREFIX	:= ${PKGDIR}${MANPATH}
-man/MANSI	:= $(subst man/,${man/IPREFIX}/man1/,${man/MANS})
-man/LMANSI	:= $(foreach l,${man/LANGS},${man/IPREFIX}/${l}/man1/snownews.1)
+mand		:= ${DESTDIR}${mandir}
+man1d		:= ${DESTDIR}${man1dir}
+lmand		:= $(foreach l,${man/langs},${mand}/${l}/man1)
+man/emani	:= $(subst man/,${man1d}/,${man/mans})
+man/lmani	:= $(foreach l,${man/langs},${mand}/${l}/man1/snownews.1)
 
-man/MANI	:= ${man/MANSI}
-${man/MANSI}:	${man/IPREFIX}/man1/%:	man/%
+${mand}:
+	@echo "Creating $@ ..."
+	@${INSTALL} -d $@
+${man1d}: | ${mand}
+	@echo "Creating $@ ..."
+	@${INSTALL} -d $@
+${lmand}: | ${mand}
+	@echo "Creating $@ ..."
+	@${INSTALL} -d $@
+man/mani	:= ${man/emani}
+${man/emani}:	${man1d}/%:	man/%	| ${man1d}
 	@echo "Installing $@ ..."
-	@${INSTALLDATA} $< $@
-
-ifdef LOCALEPATH
-man/MANI	+= ${man/LMANSI}
-${man/LMANSI}:	${man/IPREFIX}/%/man1/snownews.1:	man/snownews.%.1
+	@${INSTALL_DATA} $< $@
+ifdef localedir
+man/mani	+= ${man/lmani}
+${man/lmani}:	${mand}/%/man1/snownews.1:	man/snownews.%.1 | ${lmand}
 	@echo "Installing $@ ..."
-	@${INSTALLDATA} $< $@
+	@${INSTALL_DATA} $< $@
 endif
 
+installdirs:	${mand} ${man1d}
 install:	man/install
-man/install:	${man/MANI}
+man/install:	${man/mani}
 
 uninstall:	man/uninstall
 man/uninstall:
-	@if [ -f ${man/IPREFIX}/man1/${NAME}.1 ]; then\
-	    echo "Uninstalling ${NAME} man pages ...";\
-	    rm -f ${man/MANI};\
+	@if [ -f ${man1d}/${name}.1 ]; then\
+	    echo "Uninstalling ${name} man pages ...";\
+	    rm -f ${man/mani};\
 	fi
 endif

--- a/po/Module.mk
+++ b/po/Module.mk
@@ -1,39 +1,54 @@
 ################ Source files ##########################################
 
-po/SRCS	:= $(filter-out po/messages.po,$(wildcard po/*.po))
-po/OBJS	:= $(addprefix $O,$(po/SRCS:.po=.mo))
-LOCALES	:= $(notdir $(po/SRCS:.po=))
+po/srcs	:= $(filter-out po/messages.po,$(wildcard po/*.po))
+po/objs	:= $(addprefix $O,$(po/srcs:.po=.mo))
+locales	:= $(notdir $(po/srcs:.po=))
 
 ################ Installation ##########################################
-ifdef LOCALEPATH
-.PHONY:	po/install po/uninstall po/clean
 
-po/IPREFIX	:= ${PKGDIR}${LOCALEPATH}/
-po/ISUFFIX	:= /LC_MESSAGES/${NAME}.mo
-po/OBJSI	:= $(foreach l,${LOCALES},${po/IPREFIX}${l}${po/ISUFFIX})
+ifdef localedir
+.PHONY:	po/all po/install po/uninstall po/clean
 
-${po/OBJSI}:	${po/IPREFIX}%${po/ISUFFIX}:	po/%.po
+all:	po/all
+po/all:	${po/objs}
+
+pod		:= ${DESTDIR}${localedir}
+polds		:= $(foreach l,${locales},${pod}/${l}/LC_MESSAGES)
+po/objsi	:= $(foreach l,${polds},${l}/${name}.mo)
+
+${pod}:
+	@echo "Creating $@ ..."
+	@${INSTALL} -d $@
+${polds}: | ${pod}
+	@echo "Creating $@ ..."
+	@${INSTALL} -d $@
+${po/objsi}:	${pod}/%/LC_MESSAGES/${name}.mo:	$Opo/%.mo | ${polds}
 	@echo "Installing $@ ..."
-	@${MSGFMT} -o $Opo/$*.mo $<
-	@${INSTALLDATA} $Opo/$*.mo $@
+	@${INSTALL_DATA} $< $@
 
+installdirs:	${polds}
 install:	po/install
-po/install:	${po/OBJSI}
+po/install:	${po/objsi}
 
 uninstall:	po/uninstall
 po/uninstall:
-	@if [ -f ${po/IPREFIX}de${po/ISUFFIX} ]; then\
-	    echo "Uninstalling ${NAME} locales ...";\
-	    rm -f ${po/OBJSI};\
+	@if [ -f ${pod}/de/LC_MESSAGES/${name}.mo ]; then\
+	    echo "Uninstalling ${name} locales ...";\
+	    rm -f ${po/objsi};\
 	fi
+
+$O%.mo:	%.po
+	@echo "    Compiling $< ..."
+	@${MSGFMT} -o $@ $<
 endif
+
 ################ Maintenance ###########################################
 
 clean:	po/clean
 po/clean:
-	@if [ -d $Opo ]; then\
-	    rm -f ${po/OBJS} $Opo/.d;\
-	    rmdir ${BUILDDIR}/po;\
+	@if [ -d ${builddir}/po ]; then\
+	    rm -f ${po/objs} $Opo/.d;\
+	    rmdir ${builddir}/po;\
 	fi
 
-${po/OBJSI}: |Makefile po/Module.mk ${CONFS} $Opo/.d
+${po/objs}: Makefile po/Module.mk ${confs} | $Opo/.d


### PR DESCRIPTION
* Add DESTDIR support. Closes issue #39
* Install directories separately from files.
	install command on primitive platforms like BSD does not
	support the -D flag, so destination directories must be
	created separately. Fixes issue #36
* Add installdirs target.
	In addition to the above, installdirs target conforms to
	GNU makefile conventions.
* Make CFLAGS and LDFLAGS overridable in the Makefile.
	This is done the same way as with DESTDIR, using make CFLAGS=-w,
	which will override CFLAGS for this one build. CFLAGS variable in
	the Config.mk now contains only the optional flags, the warnings,
	and the cflags variable that Makefile uses appends CFLAGS so
	that it can override hardcoded flags in Config.mk. Note that
	configure does not look at CFLAGS environment variable; this is
	only for running make. This closes issue #43
* Check for pkg-config not being installed and don't call it then.
	I didn't check for empty output of which when I wrote this last.
	Should detect no pkg-config properly now and fall back to
	default subs. Fixes issues #35 and #41